### PR TITLE
Il2cpp compilation support

### DIFF
--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e25e5f592526f4aab8202068a92eb83d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/LRS/Domain/Domain.asmdef
+++ b/Runtime/LRS/Domain/Domain.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:713bcb041f48d19f0be3e9bccd45f278",
         "GUID:a239677e92e1442baa2eb0f9939172f0",
-        "GUID:f1ff0f022513711729e9ed0e16aceb87"
+        "GUID:f1ff0f022513711729e9ed0e16aceb87",
+        "GUID:b278dc884bb5bac48823091dd98ac2fc"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/XAPI/ActivityDefinition.cs
+++ b/Runtime/XAPI/ActivityDefinition.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Dynamic;
-using System.Collections.Generic;
 
 namespace XAPI {
     public class ActivityDefinition : IExtension {
@@ -8,6 +6,6 @@ namespace XAPI {
         public LanguageMap description {set;get;}
         public String type {set;get;}
         public String moreInfo {set;get;}
-        public Dictionary<String,ExpandoObject> extensions {set;get;}
+        public Extension extensions {set;get;}
     }
 }

--- a/Runtime/XAPI/Context.cs
+++ b/Runtime/XAPI/Context.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Dynamic;
-using System.Collections.Generic;
 
 namespace XAPI {
     public class Context: IExtension {
@@ -11,6 +9,6 @@ namespace XAPI {
         public String platform { set;get; }
         public String language { set;get; }
         public StatementReference statement { set;get; }
-        public Dictionary<String,ExpandoObject> extensions { set;get; }
+        public Extension extensions { set;get; }
     }
 }

--- a/Runtime/XAPI/ContextActivity.cs
+++ b/Runtime/XAPI/ContextActivity.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace XAPI {

--- a/Runtime/XAPI/Extension.cs
+++ b/Runtime/XAPI/Extension.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+using XAPI.Metadata;
+
+namespace XAPI {
+    public class Extension {
+        [JsonPropertyName("https://docs.unity3d.com/ScriptReference/XR.XRDisplaySubsystem.html")]
+        public VRSubsystems vrSubsystemMetadata { set; get; }
+        [JsonPropertyName("https://docs.unity3d.com/ScriptReference/XR.XRSettings.html")]
+        public VRSettings vrSettingsMetadata { set; get; }
+        [JsonPropertyName("https://docs.unity3d.com/ScriptReference/Application-platform.html")]
+        public PlatformSettings platformSettingsMetadata { set; get; }
+        [JsonPropertyName("http://ip-api.com/location")]
+        public Location location { set; get; }
+    }
+}

--- a/Runtime/XAPI/Extension.cs.meta
+++ b/Runtime/XAPI/Extension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8efc87a3def1b4cf9b636a81a5539a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/XAPI/IExtension.cs
+++ b/Runtime/XAPI/IExtension.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Dynamic;
-using System.Collections.Generic;
 
 namespace XAPI {
     public interface IExtension {
-        public Dictionary<String,ExpandoObject> extensions {set;get;}
+        public Extension extensions {set;get;}
     }
 }

--- a/Runtime/XAPI/Metadata.meta
+++ b/Runtime/XAPI/Metadata.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 628332e2b91b9f7589daf90cfc7d7a08
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/XAPI/Metadata/Location.cs
+++ b/Runtime/XAPI/Metadata/Location.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace XAPI.Metadata {
+    public class Location {
+        public String query { set; get; }
+        public String status { set; get; }
+        public String country { set; get; }
+        public String countryCode { set; get; }
+        public String region { set; get; }
+        public String regionName { set; get; }
+        public String city { set; get; }
+        public String zip { set; get; }
+        public float lat { set; get; }
+        public float lon { set; get; }
+        public String timezone { set; get; }
+        public String isp { set; get; }
+        public String org { set; get; }
+    }
+}

--- a/Runtime/XAPI/Metadata/Location.cs.meta
+++ b/Runtime/XAPI/Metadata/Location.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fd2277b9e72d9d2faeb150158a06fea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/XAPI/Metadata/Metadata.asmdef
+++ b/Runtime/XAPI/Metadata/Metadata.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "XAPI.Metadata"
+}

--- a/Runtime/XAPI/Metadata/Metadata.asmdef.meta
+++ b/Runtime/XAPI/Metadata/Metadata.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b278dc884bb5bac48823091dd98ac2fc
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/XAPI/Metadata/PlatformSettings.cs
+++ b/Runtime/XAPI/Metadata/PlatformSettings.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace XAPI.Metadata {
+    public class PlatformSettings {
+        public String platform { set; get; }
+    }
+}

--- a/Runtime/XAPI/Metadata/PlatformSettings.cs.meta
+++ b/Runtime/XAPI/Metadata/PlatformSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c8a9c3b24a21c5d35b76c0d69024ec7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/XAPI/Metadata/VRSettings.cs
+++ b/Runtime/XAPI/Metadata/VRSettings.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace XAPI.Metadata {
+    public class VRSettings {
+        public String loadedDeviceName { set; get; }
+    }
+}

--- a/Runtime/XAPI/Metadata/VRSettings.cs.meta
+++ b/Runtime/XAPI/Metadata/VRSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68849e80d02bdf5d88054cbd37f9fae6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/XAPI/Metadata/VRSubsystems.cs
+++ b/Runtime/XAPI/Metadata/VRSubsystems.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace XAPI.Metadata {
+    public class VRSubsystems {
+        public Boolean running { set; get; }
+
+    }
+}

--- a/Runtime/XAPI/Metadata/VRSubsystems.cs.meta
+++ b/Runtime/XAPI/Metadata/VRSubsystems.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 857404c2705f5141d93a8adec5deeeff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/XAPI/Result.cs
+++ b/Runtime/XAPI/Result.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Dynamic;
-using System.Collections.Generic;
 
 
 namespace XAPI {
@@ -10,7 +8,7 @@ namespace XAPI {
         public Boolean completion { get; set; }
         public String response { get; set; }
         public String duration { get; set; }
-        public Dictionary<String,ExpandoObject> extensions {set;get;}
+        public Extension extensions {set;get;}
 
     }
 }

--- a/Runtime/XAPI/XAPI.asmdef
+++ b/Runtime/XAPI/XAPI.asmdef
@@ -1,3 +1,16 @@
 {
-	"name": "XAPI"
+    "name": "XAPI",
+    "rootNamespace": "",
+    "references": [
+        "GUID:b278dc884bb5bac48823091dd98ac2fc"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Tests/Tests.asmdef
+++ b/Tests/Tests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "XAPI"
+        "XAPI",
+        "XAPI.Metadata"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Tests/XAPI/StatementTest.cs
+++ b/Tests/XAPI/StatementTest.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using XAPI;
+using XAPI.Metadata;
 
 public class StatementTest
 {
@@ -66,18 +67,19 @@ public class StatementTest
     [Test]
     public void StatementContextSet()
     {
-        dynamic tiefighter = new ExpandoObject();
-        tiefighter.alleigance = "Empire";
-        var extension = new Dictionary<String, ExpandoObject>();
 
-        extension.Add("http://wiki.com/tiefighter", tiefighter);
+        var extension = new Extension () {
+            location = new Location() {
+                region = "US"
+            }
+        };
         
         var statement = new Statement<Agent, Activity>(){
             context = new Context {
                 extensions = extension
             }
         };
-        Assert.AreSame(statement.context.extensions["http://wiki.com/tiefighter"],tiefighter);
+        Assert.AreSame(statement.context.extensions.location.region,"US");
     }
 
     [Test]


### PR DESCRIPTION
This converts extensions from what were previously dynamically compiled objects to statically compiled ones. This is a fix for iOS/android IL2CPP compilation. The reason for this is because IL2CPP doesn't support JIT which is required for dynamic typing. Documentation linked [here](https://docs.unity3d.com/Manual/ScriptingRestrictions.htmll).